### PR TITLE
[FIX] Treebuilder, pass root in class definition

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,7 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('bordeux_geo_name');
+        $treeBuilder = new TreeBuilder('bordeux_geo_name');
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for
         // more information on that topic.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@ Geonames Bundle
 ===============
 [![Build Status](https://travis-ci.org/bordeux/geoname-bundle.svg?branch=master)](https://travis-ci.org/bordeux/geoname-bundle) [![Coverage Status](https://coveralls.io/repos/github/bordeux/geoname-bundle/badge.svg?branch=master)](https://coveralls.io/github/bordeux/geoname-bundle?branch=master)[![Latest Stable Version](https://poser.pugx.org/bordeux/geoname-bundle/version)](https://packagist.org/packages/bordeux/geoname-bundle)
 
+# CREDITS [IMPORTANT]
+
+All the work was originaly done by Krzysztof Bednarczyk <krzysztof@bednarczyk.me>. This package is a fork to get a fast fix on error happening on
+symfony 5.
+
 # Introduction
 
 Provides access to the data exported by [GeoNames.org][1] into  [Symfony 2][2] and [Symfony 3][2]

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "bordeux/geoname-bundle",
+    "name": "brawcks/geoname-bundle",
     "type": "symfony-bundle",
     "description": "Symfony GeoNameBundle",
     "keywords": ["geoname", "geonameid"],


### PR DESCRIPTION
In my case, it solved the issue. It seems that there is no more root function in class, Used in the class definition instead.

See : https://symfony.com/blog/new-in-symfony-4-2-important-deprecations

Linked to : #10 