### PR TITLE
[FIX] Treebuilder, pass root in class definition

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,7 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('bordeux_geo_name');
+        $treeBuilder = new TreeBuilder('bordeux_geo_name');
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for
         // more information on that topic.


### PR DESCRIPTION
In my case, it solved the issue. It seems that there is no more root function in class, Used in the class definition instead.

See : https://symfony.com/blog/new-in-symfony-4-2-important-deprecations

Linked to : #10